### PR TITLE
Fix make module name for complex file name (e.x. file.json.js)

### DIFF
--- a/tasks/amd_tamer.js
+++ b/tasks/amd_tamer.js
@@ -81,7 +81,7 @@ module.exports = function(grunt) {
         var extension = path.extname(filepath);
         var isCoffeeScript = (extension === '.coffee');
 
-        var moduleName = filepath.split(extension)[0];
+        var moduleName = path.join(path.dirname(filepath), path.basename(filepath,extension));
         if (options.base && moduleName.indexOf(options.base) === 0) {
           moduleName = moduleName.split(options.base)[1];
         }


### PR DESCRIPTION
Task creates wrong module name for file 'module1/widgets/file.json.js' ('module1/widgets/file' instead of module1/widgets/file.json)